### PR TITLE
Create CODEOWNERS file for default reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these
+# owners will be requested for review when someone opens a
+# pull request.
+* @konflux-ci/mintmaker-maintainers


### PR DESCRIPTION
Add CODEOWNERS file to define repository maintainers. Use mintmaker team as the default CODEOWNERS.